### PR TITLE
Fix harddisk id typo in step description

### DIFF
--- a/collections/_posts/2017-12-30-decrypt-and-mount-luks-disk-from-grub-rescue-mode.md
+++ b/collections/_posts/2017-12-30-decrypt-and-mount-luks-disk-from-grub-rescue-mode.md
@@ -24,7 +24,7 @@ List all devices found (out of curiosity)
 
     grub rescue> ls
 
-Mount the encrypted */boot* partition (as attempted from the start). I know that partition number 2 on the first (and only) disk is mine, hence `(hd2,gpt2)`.
+Mount the encrypted */boot* partition (as attempted from the start). I know that partition number 2 on the first (and only) disk is mine, hence `(hd0,gpt2)`.
 
     grub rescue> cryptomount (hd0,gpt2)
 


### PR DESCRIPTION
First disk is hd0, doesn't it.
Have one instance of hd2. IMHO should be hd0.
@@ -24,7 +24,7 @@ List all devices found (out of curiosity)

    grub rescue> ls

- Mount the encrypted */boot* partition (as attempted from the start). I know that partition number 2 on the first (and only) disk is mine, hence `(hd2,gpt2)`.
+ Mount the encrypted */boot* partition (as attempted from the start). I know that partition number 2 on the first (and only) disk is mine, hence `(hd0,gpt2)`.

    grub rescue> cryptomount (hd0,gpt2)

